### PR TITLE
Add feature to raise error for undocumented definitions

### DIFF
--- a/docs/class.Facebook.HHAPIDoc.DocumentationBuilderContext.__construct.html
+++ b/docs/class.Facebook.HHAPIDoc.DocumentationBuilderContext.__construct.html
@@ -40,6 +40,7 @@
   Facebook\HHAPIDoc\Index $index,
   IPathProvider</span><span class="hs-MarkupSuffix"><span class="hs-LessThanQuestionToken">&lt;?</span></span></span><span class="hs-ExpressionStatement"><span class="hs-BinaryExpression"><span class="hs-NameToken">string</span><span class="hs-GreaterThanToken">&gt; </span><span class="hs-VariableExpression"><span class="hs-VariableToken">$pathProvider</span></span></span></span><span class="hs-ExpressionStatement"><span class="hs-CommaToken">,
 </span></span><span class="hs-ExpressionStatement"><span class="hs-NameToken">  bool </span></span><span class="hs-ExpressionStatement"><span class="hs-VariableExpression"><span class="hs-VariableToken">$syntaxHighlightingOn</span></span></span><span class="hs-ExpressionStatement"><span class="hs-CommaToken">,
+</span></span><span class="hs-ExpressionStatement"><span class="hs-NameToken">  bool </span></span><span class="hs-ExpressionStatement"><span class="hs-VariableExpression"><span class="hs-VariableToken">$raiseErrorOnUndocumentedDefinitions</span></span></span><span class="hs-ExpressionStatement"><span class="hs-CommaToken">,
 </span><span class="hs-SemicolonToken">);</span></span><span class="hs-EndOfFile"><span class="hs-EndOfFileToken"></span></span></span></code></pre>
 
 <h2>Parameters</h2>
@@ -50,6 +51,7 @@ autolinking.</li>
 <li><code>IPathProvider&lt;?string&gt; $pathProvider</code> a path provider that returns paths for documentables
 that exist, or null for ones that don't.</li>
 <li><code>bool $syntaxHighlightingOn</code></li>
+<li><code>bool $raiseErrorOnUndocumentedDefinitions</code></li>
 </ul>
 
 </body>

--- a/docs/class.Facebook.HHAPIDoc.DocumentationBuilderContext.html
+++ b/docs/class.Facebook.HHAPIDoc.DocumentationBuilderContext.html
@@ -43,11 +43,12 @@ class </span><span class="hs-NameToken">DocumentationBuilderContext </span><span
 <h3>Public Methods</h3>
 <ul>
 <li><a href="class.Facebook.HHAPIDoc.DocumentationBuilderContext.IsSyntaxHighlightingOn.html"><code>-&gt;IsSyntaxHighlightingOn(): bool</code></a></li>
-<li><a href="class.Facebook.HHAPIDoc.DocumentationBuilderContext.__construct.html"><code>-&gt;__construct(OutputFormat $format, Index $index, \IPathProvider&lt;?string&gt; $pathProvider, bool $syntaxHighlightingOn)</code></a><br />
+<li><a href="class.Facebook.HHAPIDoc.DocumentationBuilderContext.__construct.html"><code>-&gt;__construct(OutputFormat $format, Index $index, \IPathProvider&lt;?string&gt; $pathProvider, bool $syntaxHighlightingOn, bool $raiseErrorOnUndocumentedDefinitions)</code></a><br />
 Create an instance</li>
 <li><a href="class.Facebook.HHAPIDoc.DocumentationBuilderContext.getIndex.html"><code>-&gt;getIndex(): Index</code></a></li>
 <li><a href="class.Facebook.HHAPIDoc.DocumentationBuilderContext.getOutputFormat.html"><code>-&gt;getOutputFormat(): OutputFormat</code></a></li>
 <li><a href="class.Facebook.HHAPIDoc.DocumentationBuilderContext.getPathProvider.html"><code>-&gt;getPathProvider(): \IPathProvider&lt;?string&gt;</code></a></li>
+<li><a href="class.Facebook.HHAPIDoc.DocumentationBuilderContext.shouldRaiseErrorOnUndocumentedDefinitions.html"><code>-&gt;shouldRaiseErrorOnUndocumentedDefinitions(): bool</code></a></li>
 </ul>
 
 </body>

--- a/docs/class.Facebook.HHAPIDoc.DocumentationBuilderContext.shouldRaiseErrorOnUndocumentedDefinitions.html
+++ b/docs/class.Facebook.HHAPIDoc.DocumentationBuilderContext.shouldRaiseErrorOnUndocumentedDefinitions.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+<title>Facebook\HHAPIDoc\DocumentationBuilderContext::shouldRaiseErrorOnUndocumentedDefinitions</title>
+<style>
+/* Keywords */
+
+.hs-FunctionToken,
+.hs-NamespaceToken {
+  color: #c678dd;
+}
+
+/* Types */
+
+.hs-SimpleTypeSpecifier .hs-StringToken {
+  color: #e5c07b;
+}
+
+.hs-ClassDeclaration .hs-NameToken {
+  color: #e5c07b;
+}
+
+/* Functions */
+
+.hs-FunctionDeclaration .hs-NameToken {
+  color: #61afef;
+}
+
+/* Variables */
+
+.hs-VariableToken {
+  color: #e06c75;
+}
+</style>
+</head>
+<body>
+<h1>Facebook\HHAPIDoc\DocumentationBuilderContext::shouldRaiseErrorOnUndocumentedDefinitions()</h1>
+<pre><code class="language-Hack"><span class="hs-Script"><span class="hs-MarkupSection"></span><span class="hs-ExpressionStatement"><span class="hs-NameToken">public </span></span><span class="hs-FunctionDeclaration"><span class="hs-FunctionDeclarationHeader"><span class="hs-FunctionToken">function </span><span class="hs-NameToken">shouldRaiseErrorOnUndocumentedDefinitions</span><span class="hs-LeftParenToken">(</span><span class="hs-RightParenToken">)</span><span class="hs-ColonToken">: </span><span class="hs-SimpleTypeSpecifier"><span class="hs-BoolToken">bool</span></span></span><span class="hs-SemicolonToken">;</span></span><span class="hs-EndOfFile"><span class="hs-EndOfFileToken"></span></span></span></code></pre>
+
+<h2>Returns</h2>
+<ul>
+<li><code>bool</code></li>
+</ul>
+
+</body>
+</html>

--- a/docs/class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.__construct.html
+++ b/docs/class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.__construct.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+<title>Facebook\HHAPIDoc\Exceptions\UndocumentedDefinitionException::__construct</title>
+<style>
+/* Keywords */
+
+.hs-FunctionToken,
+.hs-NamespaceToken {
+  color: #c678dd;
+}
+
+/* Types */
+
+.hs-SimpleTypeSpecifier .hs-StringToken {
+  color: #e5c07b;
+}
+
+.hs-ClassDeclaration .hs-NameToken {
+  color: #e5c07b;
+}
+
+/* Functions */
+
+.hs-FunctionDeclaration .hs-NameToken {
+  color: #61afef;
+}
+
+/* Variables */
+
+.hs-VariableToken {
+  color: #e06c75;
+}
+</style>
+</head>
+<body>
+<h1>Facebook\HHAPIDoc\Exceptions\UndocumentedDefinitionException::__construct()</h1>
+<pre><code class="language-Hack"><span class="hs-Script"><span class="hs-MarkupSection"></span><span class="hs-ExpressionStatement"><span class="hs-NameToken">public </span></span><span class="hs-FunctionDeclaration"><span class="hs-FunctionDeclarationHeader"><span class="hs-FunctionToken">function </span><span class="hs-ConstructToken">__construct</span><span class="hs-LeftParenToken">(
+</span><span class="hs-ListItem"><span class="hs-ParameterDeclaration"><span class="hs-SimpleTypeSpecifier"><span class="hs-StringToken">  string </span></span><span class="hs-VariableToken">$fieldname</span></span><span class="hs-CommaToken">,
+</span></span><span class="hs-ListItem"><span class="hs-ParameterDeclaration"><span class="hs-SimpleTypeSpecifier"><span class="hs-StringToken">  string </span></span><span class="hs-VariableToken">$fileName</span></span><span class="hs-CommaToken">,
+</span></span><span class="hs-RightParenToken">)</span></span><span class="hs-SemicolonToken">;</span></span><span class="hs-EndOfFile"><span class="hs-EndOfFileToken"></span></span></span></code></pre>
+
+<h2>Parameters</h2>
+<ul>
+<li><code>string $fieldname</code></li>
+<li><code>string $fileName</code></li>
+</ul>
+
+</body>
+</html>

--- a/docs/class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.getMessage.html
+++ b/docs/class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.getMessage.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+<title>Facebook\HHAPIDoc\Exceptions\UndocumentedDefinitionException::getMessage</title>
+<style>
+/* Keywords */
+
+.hs-FunctionToken,
+.hs-NamespaceToken {
+  color: #c678dd;
+}
+
+/* Types */
+
+.hs-SimpleTypeSpecifier .hs-StringToken {
+  color: #e5c07b;
+}
+
+.hs-ClassDeclaration .hs-NameToken {
+  color: #e5c07b;
+}
+
+/* Functions */
+
+.hs-FunctionDeclaration .hs-NameToken {
+  color: #61afef;
+}
+
+/* Variables */
+
+.hs-VariableToken {
+  color: #e06c75;
+}
+</style>
+</head>
+<body>
+<h1>Facebook\HHAPIDoc\Exceptions\UndocumentedDefinitionException::getMessage()</h1>
+<pre><code class="language-Hack"><span class="hs-Script"><span class="hs-MarkupSection"></span><span class="hs-ExpressionStatement"><span class="hs-NameToken">public </span></span><span class="hs-FunctionDeclaration"><span class="hs-FunctionDeclarationHeader"><span class="hs-FunctionToken">function </span><span class="hs-NameToken">getMessage</span><span class="hs-LeftParenToken">(</span><span class="hs-RightParenToken">)</span><span class="hs-ColonToken">: </span><span class="hs-SimpleTypeSpecifier"><span class="hs-StringToken">string</span></span></span><span class="hs-SemicolonToken">;</span></span><span class="hs-EndOfFile"><span class="hs-EndOfFileToken"></span></span></span></code></pre>
+
+<h2>Returns</h2>
+<ul>
+<li><code>string</code></li>
+</ul>
+
+</body>
+</html>

--- a/docs/class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.html
+++ b/docs/class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+<title>Facebook\HHAPIDoc\Exceptions\UndocumentedDefinitionException</title>
+<style>
+/* Keywords */
+
+.hs-FunctionToken,
+.hs-NamespaceToken {
+  color: #c678dd;
+}
+
+/* Types */
+
+.hs-SimpleTypeSpecifier .hs-StringToken {
+  color: #e5c07b;
+}
+
+.hs-ClassDeclaration .hs-NameToken {
+  color: #e5c07b;
+}
+
+/* Functions */
+
+.hs-FunctionDeclaration .hs-NameToken {
+  color: #61afef;
+}
+
+/* Variables */
+
+.hs-VariableToken {
+  color: #e06c75;
+}
+</style>
+</head>
+<body>
+<h1>Facebook\HHAPIDoc\Exceptions\UndocumentedDefinitionException</h1>
+<p>Exception thrown on undocumented definition</p>
+<h2>Interface Synopsis</h2>
+<pre><code class="language-Hack"><span class="hs-Script"><span class="hs-MarkupSection"></span><span class="hs-NamespaceDeclaration"><span class="hs-NamespaceToken">namespace </span><span class="hs-QualifiedName"><span class="hs-ListItem"><span class="hs-NameToken">Facebook</span><span class="hs-BackslashToken">\</span></span><span class="hs-ListItem"><span class="hs-NameToken">HHAPIDoc</span><span class="hs-BackslashToken">\</span></span><span class="hs-ListItem"><span class="hs-NameToken">Exceptions</span></span></span><span class="hs-NamespaceEmptyBody"><span class="hs-SemicolonToken">;
+</span></span></span><span class="hs-ClassishDeclaration"><span class="hs-FinalToken">
+final </span><span class="hs-ClassToken">class </span><span class="hs-NameToken">UndocumentedDefinitionException </span><span class="hs-ExtendsToken">extends </span><span class="hs-ListItem"><span class="hs-SimpleTypeSpecifier"><span class="hs-QualifiedName"><span class="hs-ListItem"><span class="hs-BackslashToken">\</span></span><span class="hs-ListItem"><span class="hs-NameToken">Exception </span></span></span></span></span><span class="hs-ClassishBody"><span class="hs-LeftBraceToken">{</span><span class="hs-ErrorSyntax"><span class="hs-DotDotDotToken">...</span></span><span class="hs-RightBraceToken">}</span></span></span><span class="hs-EndOfFile"><span class="hs-EndOfFileToken"></span></span></span></code></pre>
+
+<h3>Public Methods</h3>
+<ul>
+<li><a href="class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.__construct.html"><code>-&gt;__construct(string $fieldname, string $fileName)</code></a></li>
+<li><a href="class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.getMessage.html"><code>-&gt;getMessage(): string</code></a></li>
+</ul>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
 <li><a href="class.Facebook.HHAPIDoc.DocBlock.DocBlock.html">Facebook\HHAPIDoc\DocBlock\DocBlock</a></li>
 <li><a href="class.Facebook.HHAPIDoc.DocumentationBuilder.html">Facebook\HHAPIDoc\DocumentationBuilder</a></li>
 <li><a href="class.Facebook.HHAPIDoc.DocumentationBuilderContext.html">Facebook\HHAPIDoc\DocumentationBuilderContext</a></li>
+<li><a href="class.Facebook.HHAPIDoc.Exceptions.UndocumentedDefinitionException.html">Facebook\HHAPIDoc\Exceptions\UndocumentedDefinitionException</a></li>
 <li><a href="class.Facebook.HHAPIDoc.GeneratorCLI.html">Facebook\HHAPIDoc\GeneratorCLI</a></li>
 <li><a href="class.Facebook.HHAPIDoc.IndexDocumentBuilder.html">Facebook\HHAPIDoc\IndexDocumentBuilder</a></li>
 <li><a href="class.Facebook.HHAPIDoc.IndexedPathProvider.html">Facebook\HHAPIDoc\IndexedPathProvider</a></li>

--- a/src/DocumentationBuilderContext.hh
+++ b/src/DocumentationBuilderContext.hh
@@ -25,6 +25,7 @@ class DocumentationBuilderContext {
     private Index $index,
     private IPathProvider<?string> $pathProvider,
     private bool $syntaxHighlightingOn,
+    private bool $raiseErrorOnUndocumentedDefinitions,
   ) {
   }
 
@@ -46,6 +47,11 @@ class DocumentationBuilderContext {
   /** @selfdocumenting */
   public function IsSyntaxHighlightingOn(): bool {
     return $this->syntaxHighlightingOn;
+  }
+
+  /** @selfdocumenting */
+  public function shouldRaiseErrorOnUndocumentedDefinitions(): bool {
+    return $this->raiseErrorOnUndocumentedDefinitions;
   }
 
 }

--- a/src/Exceptions/UndocumentedDefinitionException.hh
+++ b/src/Exceptions/UndocumentedDefinitionException.hh
@@ -1,0 +1,33 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAPIDoc\Exceptions;
+
+/**
+ * Exception thrown on undocumented definition
+ */
+final class UndocumentedDefinitionException extends \Exception {
+
+  <<__Override>>
+  public function __construct(
+    private string $fieldname,
+    private string $fileName,
+  ) {}
+
+  <<__Override>>
+  public function getMessage(): string {
+    return "Error while generating documentation: ".
+      "Undocumented definition '".
+      $this->fieldname.
+      "' found ".
+      "at path: ".
+      $this->fileName."\n";
+  }
+}

--- a/src/Exceptions/UndocumentedDefinitionException.hh
+++ b/src/Exceptions/UndocumentedDefinitionException.hh
@@ -19,7 +19,9 @@ final class UndocumentedDefinitionException extends \Exception {
   public function __construct(
     private string $fieldname,
     private string $fileName,
-  ) {}
+  ) {
+    parent::__construct();
+  }
 
   <<__Override>>
   public function getMessage(): string {


### PR DESCRIPTION
Fix #14 
<img width="1331" alt="screen shot 2018-08-12 at 11 30 35 pm" src="https://user-images.githubusercontent.com/19752696/44007117-bff1f552-9e87-11e8-9abd-b4166ec05363.png">

And yes, it looks much better with verbose! 
<img width="1328" alt="screen shot 2018-08-12 at 11 41 28 pm" src="https://user-images.githubusercontent.com/19752696/44007217-5518254c-9e89-11e8-8ffe-3e3fc378366f.png">
