### PR TITLE
Use an (untyped) Hack script as the binary

### DIFF
--- a/bin/hh-apidoc
+++ b/bin/hh-apidoc
@@ -1,2 +1,22 @@
-#!/bin/sh
-exec "$(dirname "$0")/hh-apidoc.hack" "$@"
+#!/usr/bin/env hhvm
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAPIDoc;
+
+// As this file does not have an extension, it is not typechecked. Delegate
+// to the typechecked one.
+<<__EntryPoint>>
+async function cli_main_UNSAFE(): Awaitable<noreturn> {
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once(__DIR__.'/hh-apidoc.hack');
+  })();
+  await cli_main();
+}


### PR DESCRIPTION
The README.md specifies that you should run the binary using hhvm.
The binary is actually a shell script.
This causes the following error:

```
The previous version gave this error and did not execute anything.
Fatal error: Uncaught Error: A semicolon (';') is expected here
 in /path/to/hh-apidoc/bin/hh-apidoc:2
Stack trace:
#0 {main}
```

I've cloned this style of binary from hhast.