### PR TITLE
[ DO NOT MERGE | Segmentation fault ] Composer fails on segfault for hhvm --php -d hhvm.jit=0 -r "echo HHVM_VERSION;"

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -7,7 +7,7 @@ php --version
 
 (
   cd $(mktemp -d)
-  curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+  curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version="1.9.3"
 )
 composer install
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -9,6 +9,7 @@ php --version
   cd $(mktemp -d)
   curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version="1.9.3"
 )
+hhvm --php -d hhvm.jit=0 -r "echo HHVM_VERSION;"
 composer install
 
 hh_client


### PR DESCRIPTION
Composer fails with a generic error on modern hhvm versions.
A suggestion to use version 1.9 was made.
This is not intended to be the solution to be build failures.
Projects should be migrated to GA instead.