### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 tests/ export-ignore
 .hhconfig export-ignore
+.hhvmconfig.hdf export-ignore
 *.hack linguist-language=Hack

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,11 @@
   "bin": [ "bin/hh-apidoc", "bin/hh-apidoc.hack" ],
   "license": "MIT",
   "require": {
-    "hhvm": "^4.102",
-    "hhvm/hsl": "^4.0",
-    "hhvm/hsl-experimental": "^4.53",
+    "hhvm": "^4.128",
     "facebook/fbmarkdown": "^1.6.5",
     "facebook/hh-clilib": "^2.1.0",
     "facebook/definition-finder": "^2.13.0",
-    "hhvm/hhast": "^4.80",
-    "hhvm/hsl-io": "^0.2.1|^0.3"
+    "hhvm/hhast": "^4.80"
   },
   "require-dev": {
     "hhvm/hhvm-autoload": "^2.0|^3.0"

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
   },
   "require-dev": {
     "hhvm/hhvm-autoload": "^2.0|^3.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "hhvm/hhvm-autoload": true
+    }
   }
 }

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -1,5 +1,6 @@
 {
     "roots": [ "src/" ],
     "devRoots": [],
-    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+    "useFactsIfAvailable": true
 }

--- a/src/DocBlock/DocBlock.hack
+++ b/src/DocBlock/DocBlock.hack
@@ -37,7 +37,7 @@ final class DocBlock {
       |> Str\strip_suffix($$, '*/')
       |> Str\trim($$)
       |> Str\split($$, "\n")
-      |> Vec\map($$, $l ==> Str\trim_left($l));
+      |> Vec\map($$, Str\trim_left<>);
 
     $content_lines = vec[];
     $finished_content = false;
@@ -238,7 +238,7 @@ final class DocBlock {
       |> Str\strip_prefix($$, '[')
       |> Str\strip_suffix($$, ']')
       |> Str\split($$, '|')
-      |> Vec\map($$, $x ==> Str\trim($x));
+      |> Vec\map($$, Str\trim<>);
   }
 
   /** Return information on function parameters from `@param` tags */

--- a/src/GeneratorCLI.hack
+++ b/src/GeneratorCLI.hack
@@ -132,7 +132,7 @@ final class GeneratorCLI extends CLIWithRequiredArguments {
           /* HHAST_IGNORE_ERROR[DontUseAsioJoin] */
           \HH\Asio\join(TreeParser::fromPathAsync($root)),
       )
-      |> Vec\map($$, $parser ==> Documentables\from_parser($parser))
+      |> Vec\map($$, Documentables\from_parser<>)
       |> Vec\flatten($$);
   }
 


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.