### PR TITLE
Fix some lints reported by CI on HHVM latest

### DIFF
--- a/src/DocBlock/DocBlock.hack
+++ b/src/DocBlock/DocBlock.hack
@@ -37,7 +37,7 @@ final class DocBlock {
       |> Str\strip_suffix($$, '*/')
       |> Str\trim($$)
       |> Str\split($$, "\n")
-      |> Vec\map($$, $l ==> Str\trim_left($l));
+      |> Vec\map($$, Str\trim_left<>);
 
     $content_lines = vec[];
     $finished_content = false;
@@ -238,7 +238,7 @@ final class DocBlock {
       |> Str\strip_prefix($$, '[')
       |> Str\strip_suffix($$, ']')
       |> Str\split($$, '|')
-      |> Vec\map($$, $x ==> Str\trim($x));
+      |> Vec\map($$, Str\trim<>);
   }
 
   /** Return information on function parameters from `@param` tags */

--- a/src/GeneratorCLI.hack
+++ b/src/GeneratorCLI.hack
@@ -132,7 +132,7 @@ final class GeneratorCLI extends CLIWithRequiredArguments {
           /* HHAST_IGNORE_ERROR[DontUseAsioJoin] */
           \HH\Asio\join(TreeParser::fromPathAsync($root)),
       )
-      |> Vec\map($$, $parser ==> Documentables\from_parser($parser))
+      |> Vec\map($$, Documentables\from_parser<>)
       |> Vec\flatten($$);
   }
 


### PR DESCRIPTION
Our CI was reporting a number of "You have made a lambda which forwards all its arguments to a static method or function." lints on HHVM latest. Apply the changes suggested by the linter.